### PR TITLE
Revert "common: Remove DT Task"

### DIFF
--- a/generate_extra_images.mk
+++ b/generate_extra_images.mk
@@ -90,6 +90,34 @@ ALL_MODULES.$(LOCAL_MODULE).INSTALLED += $(INSTALLED_PERSISTIMAGE_TARGET)
 
 endif
 
+#----------------------------------------------------------------------
+# Generate device tree image (dt.img)
+#----------------------------------------------------------------------
+ifeq ($(strip $(BOARD_KERNEL_SEPARATED_DT)),true)
+ifeq ($(strip $(BUILD_TINY_ANDROID)),true)
+include device/qcom/common/dtbtool/Android.mk
+endif
+
+DTBTOOL := $(HOST_OUT_EXECUTABLES)/dtbTool$(HOST_EXECUTABLE_SUFFIX)
+
+INSTALLED_DTIMAGE_TARGET := $(PRODUCT_OUT)/dt.img
+
+possible_dtb_dirs = $(KERNEL_OUT)/arch/arm/boot/dts/ $(KERNEL_OUT)/arch/arm/boot/
+dtb_dir = $(firstword $(wildcard $(possible_dtb_dirs)))
+
+define build-dtimage-target
+    $(call pretty,"Target dt image: $(INSTALLED_DTIMAGE_TARGET)")
+    $(hide) $(DTBTOOL) -o $@ -s $(BOARD_KERNEL_PAGESIZE) -p $(KERNEL_OUT)/scripts/dtc/ $(dtb_dir)
+    $(hide) chmod a+r $@
+endef
+
+$(INSTALLED_DTIMAGE_TARGET): $(DTBTOOL) $(INSTALLED_KERNEL_TARGET)
+	$(build-dtimage-target)
+
+ALL_DEFAULT_INSTALLED_MODULES += $(INSTALLED_DTIMAGE_TARGET)
+ALL_MODULES.$(LOCAL_MODULE).INSTALLED += $(INSTALLED_DTIMAGE_TARGET)
+endif
+
 #---------------------------------------------------------------------
 # Generate usbdisk.img FAT32 image
 # Please NOTICE: the valid max size of usbdisk.bin is 10GB


### PR DESCRIPTION
This reverts commit f19465ed286aa94e78342a447e7c7f898f3bad0a.

This fixes an error where dt.img will not build thus stops the entire build process. It may not be the best solution but it works
